### PR TITLE
Replace 'GreaterThan' by 'GreaterThanOrEquals' and 'StrictGreaterThan' by 'GreaterThan' (same thing for 'LessThan') and other changes

### DIFF
--- a/src/Asserts/TraitAssertComparison.php
+++ b/src/Asserts/TraitAssertComparison.php
@@ -17,12 +17,13 @@ trait TraitAssertComparison
     use AbstractTraitAssert;
 
     /**
-     * Asserts that the given values are equals.
+     * Asserts that the given actual value equals the expected value.
      *
      * @param mixed $actual The actual value to test.
      * @param mixed $expected The expected value.
      * @param mixed $exception The exception to throw if the assertion fails.
      * @return mixed The actual value tested.
+     * @throws \Exception
      */
     public static function assertEquals($actual, $expected, $exception)
     {
@@ -32,26 +33,28 @@ trait TraitAssertComparison
     }
 
     /**
-     * Asserts that the given values are strictly equals.
+     * Asserts that the given actual value strictly equals the expected value.
      *
      * @param mixed $actual The actual value to test.
      * @param mixed $expected The expected value.
      * @param mixed $exception The exception to throw if the assertion fails.
      * @return mixed The actual value tested.
+     * @throws \Exception
      */
-    public static function assertStrictEquals($actual, $expected, $exception)
+    public static function assertStrictlyEquals($actual, $expected, $exception)
     {
         static::makeAssertion($actual === $expected, $exception);
         return $actual;
     }
 
     /**
-     * Asserts that the given values are not equals.
+     * Asserts that the given actual value does not equal the expected value.
      *
      * @param mixed $actual The actual value to test.
      * @param mixed $expected The expected value.
      * @param mixed $exception The exception to throw if the assertion fails.
      * @return mixed The actual value tested.
+     * @throws \Exception
      */
     public static function assertNotEquals($actual, $expected, $exception)
     {
@@ -61,17 +64,33 @@ trait TraitAssertComparison
     }
 
     /**
-     * Asserts that the given values are strictly not equals.
+     * Asserts that the given actual value does not strictly equal the expected value.
      *
      * @param mixed $actual The actual value to test.
      * @param mixed $expected The expected value.
      * @param mixed $exception The exception to throw if the assertion fails.
      * @return mixed The actual value tested.
+     * @throws \Exception
      */
-    public static function assertStrictNotEquals($actual, $expected, $exception)
+    public static function assertNotStrictlyEquals($actual, $expected, $exception)
     {
         static::makeAssertion($actual !== $expected, $exception);
         return $actual;
+    }
+
+    /**
+     * Asserts that the given actual value is greater than or equals the expected value.
+     *
+     * @param mixed $actual The actual value to test.
+     * @param mixed $expected The expected value.
+     * @param mixed $exception The exception to throw if the assertion fails.
+     * @return bool
+     * @throws \Exception
+     */
+    public static function assertGreaterThanOrEquals($actual, $expected, $exception): bool
+    {
+        static::makeAssertion($actual >= $expected, $exception);
+        return true;
     }
 
     /**
@@ -81,24 +100,26 @@ trait TraitAssertComparison
      * @param mixed $expected The expected value.
      * @param mixed $exception The exception to throw if the assertion fails.
      * @return bool
+     * @throws \Exception
      */
     public static function assertGreaterThan($actual, $expected, $exception): bool
     {
-        static::makeAssertion($actual >= $expected, $exception);
+        static::makeAssertion($actual > $expected, $exception);
         return true;
     }
 
     /**
-     * Asserts that the given actual value is strictly greater than the expected value.
+     * Asserts that the given actual value is less than or equals the expected value.
      *
      * @param mixed $actual The actual value to test.
      * @param mixed $expected The expected value.
      * @param mixed $exception The exception to throw if the assertion fails.
      * @return bool
+     * @throws \Exception
      */
-    public static function assertStrictGreaterThan($actual, $expected, $exception): bool
+    public static function assertLessThanOrEquals($actual, $expected, $exception): bool
     {
-        static::makeAssertion($actual > $expected, $exception);
+        static::makeAssertion($actual <= $expected, $exception);
         return true;
     }
 
@@ -109,22 +130,9 @@ trait TraitAssertComparison
      * @param mixed $expected The expected value.
      * @param mixed $exception The exception to throw if the assertion fails.
      * @return bool
+     * @throws \Exception
      */
     public static function assertLessThan($actual, $expected, $exception): bool
-    {
-        static::makeAssertion($actual <= $expected, $exception);
-        return true;
-    }
-
-    /**
-     * Asserts that the given actual value is strictly less than the expected value.
-     *
-     * @param mixed $actual The actual value to test.
-     * @param mixed $expected The expected value.
-     * @param mixed $exception The exception to throw if the assertion fails.
-     * @return bool
-     */
-    public static function assertStrictLessThan($actual, $expected, $exception): bool
     {
         static::makeAssertion($actual < $expected, $exception);
         return true;

--- a/src/Tests/Asserts/TraitComparison/GreaterThanOrEqualsTest.php
+++ b/src/Tests/Asserts/TraitComparison/GreaterThanOrEqualsTest.php
@@ -8,7 +8,7 @@ use Nicodev\Asserts\TraitAssertComparison;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Final class StrictGreaterThanTest
+ * Final class GreaterThanOrEqualsTest
  *
  * @category Tests
  * @package Nicodev\Tests\Asserts
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  * @copyright (c) 2017 Nicolas Giraud
  * @license MIT
  */
-final class StrictGreaterThanTest extends TestCase
+final class GreaterThanOrEqualsTest extends TestCase
 {
     /**
      * @var object anonymous class
@@ -41,7 +41,7 @@ final class StrictGreaterThanTest extends TestCase
              */
             public function runOk(): bool
             {
-                return static::assertStrictGreaterThan(100, 1, new Exception('This assertion fails.'));
+                return static::assertGreaterThanOrEquals(100, 100, new Exception('This assertion fails.'));
             }
 
             /**
@@ -50,7 +50,7 @@ final class StrictGreaterThanTest extends TestCase
              */
             public function runKo(): bool
             {
-                return static::assertStrictGreaterThan(100, 100, new Exception('This assertion fails.'));
+                return static::assertGreaterThanOrEquals(1, 100, new Exception('This assertion fails.'));
             }
         };
     }

--- a/src/Tests/Asserts/TraitComparison/GreaterThanTest.php
+++ b/src/Tests/Asserts/TraitComparison/GreaterThanTest.php
@@ -41,7 +41,7 @@ final class GreaterThanTest extends TestCase
              */
             public function runOk(): bool
             {
-                return static::assertGreaterThan(100, 100, new Exception('This assertion fails.'));
+                return static::assertGreaterThan(100, 1, new Exception('This assertion fails.'));
             }
 
             /**
@@ -50,7 +50,7 @@ final class GreaterThanTest extends TestCase
              */
             public function runKo(): bool
             {
-                return static::assertGreaterThan(1, 100, new Exception('This assertion fails.'));
+                return static::assertGreaterThan(100, 100, new Exception('This assertion fails.'));
             }
         };
     }

--- a/src/Tests/Asserts/TraitComparison/LessThanOrEqualsTest.php
+++ b/src/Tests/Asserts/TraitComparison/LessThanOrEqualsTest.php
@@ -8,7 +8,7 @@ use Nicodev\Asserts\TraitAssertComparison;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Final class StrictEqualsTest
+ * Final class LessThanOrEqualsTest
  *
  * @category Tests
  * @package Nicodev\Tests\Asserts
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  * @copyright (c) 2017 Nicolas Giraud
  * @license MIT
  */
-final class StrictEqualsTest extends TestCase
+final class LessThanOrEqualsTest extends TestCase
 {
     /**
      * @var object anonymous class
@@ -37,27 +37,27 @@ final class StrictEqualsTest extends TestCase
 
             /**
              * Run the assertion is ok for test.
-             * @return mixed
+             * @return bool
              */
-            public function runOk()
+            public function runOk(): bool
             {
-                return static::assertStrictEquals(true, true, new Exception('This assertion fails.'));
+                return static::assertLessThanOrEquals(1, 1, new Exception('This assertion fails.'));
             }
 
             /**
              * Run the assertion is KO for test.
-             * @return mixed
+             * @return bool
              */
-            public function runKo()
+            public function runKo(): bool
             {
-                return static::assertStrictEquals(true, 1, new Exception('This assertion fails.'));
+                return static::assertLessThanOrEquals(100, 1, new Exception('This assertion fails.'));
             }
         };
     }
 
     public function testMakeAssertionOK()
     {
-        static::assertSame(true, $this->testClass->runOk());
+        static::assertTrue($this->testClass->runOk());
     }
 
     public function testMakeAssertionKO()

--- a/src/Tests/Asserts/TraitComparison/LessThanTest.php
+++ b/src/Tests/Asserts/TraitComparison/LessThanTest.php
@@ -41,7 +41,7 @@ final class LessThanTest extends TestCase
              */
             public function runOk(): bool
             {
-                return static::assertLessThan(1, 1, new Exception('This assertion fails.'));
+                return static::assertLessThan(1, 100, new Exception('This assertion fails.'));
             }
 
             /**
@@ -50,7 +50,7 @@ final class LessThanTest extends TestCase
              */
             public function runKo(): bool
             {
-                return static::assertLessThan(100, 1, new Exception('This assertion fails.'));
+                return static::assertLessThan(1, 1, new Exception('This assertion fails.'));
             }
         };
     }

--- a/src/Tests/Asserts/TraitComparison/NotStrictlyEqualsTest.php
+++ b/src/Tests/Asserts/TraitComparison/NotStrictlyEqualsTest.php
@@ -8,7 +8,7 @@ use Nicodev\Asserts\TraitAssertComparison;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Final class StrictNotEqualsTest
+ * Final class NotStrictlyEqualsTest
  *
  * @category Tests
  * @package Nicodev\Tests\Asserts
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  * @copyright (c) 2017 Nicolas Giraud
  * @license MIT
  */
-final class StrictNotEqualsTest extends TestCase
+final class NotStrictlyEqualsTest extends TestCase
 {
     /**
      * @var object anonymous class
@@ -41,7 +41,7 @@ final class StrictNotEqualsTest extends TestCase
              */
             public function runOk()
             {
-                return static::assertStrictNotEquals('1', 1, new Exception('This assertion fails.'));
+                return static::assertNotStrictlyEquals('1', 1, new Exception('This assertion fails.'));
             }
 
             /**
@@ -50,7 +50,7 @@ final class StrictNotEqualsTest extends TestCase
              */
             public function runKo()
             {
-                return static::assertStrictNotEquals('1', '1', new Exception('This assertion fails.'));
+                return static::assertNotStrictlyEquals('1', '1', new Exception('This assertion fails.'));
             }
         };
     }

--- a/src/Tests/Asserts/TraitComparison/StrictlyEqualsTest.php
+++ b/src/Tests/Asserts/TraitComparison/StrictlyEqualsTest.php
@@ -8,7 +8,7 @@ use Nicodev\Asserts\TraitAssertComparison;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Final class StrictLessThanTest
+ * Final class StrictlyEqualsTest
  *
  * @category Tests
  * @package Nicodev\Tests\Asserts
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  * @copyright (c) 2017 Nicolas Giraud
  * @license MIT
  */
-final class StrictLessThanTest extends TestCase
+final class StrictlyEqualsTest extends TestCase
 {
     /**
      * @var object anonymous class
@@ -37,27 +37,27 @@ final class StrictLessThanTest extends TestCase
 
             /**
              * Run the assertion is ok for test.
-             * @return bool
+             * @return mixed
              */
-            public function runOk(): bool
+            public function runOk()
             {
-                return static::assertStrictLessThan(1, 100, new Exception('This assertion fails.'));
+                return static::assertStrictlyEquals(true, true, new Exception('This assertion fails.'));
             }
 
             /**
              * Run the assertion is KO for test.
-             * @return bool
+             * @return mixed
              */
-            public function runKo(): bool
+            public function runKo()
             {
-                return static::assertStrictLessThan(1, 1, new Exception('This assertion fails.'));
+                return static::assertStrictlyEquals(true, 1, new Exception('This assertion fails.'));
             }
         };
     }
 
     public function testMakeAssertionOK()
     {
-        static::assertTrue($this->testClass->runOk());
+        static::assertSame(true, $this->testClass->runOk());
     }
 
     public function testMakeAssertionKO()


### PR DESCRIPTION
Add @throws when needed
Fix 'are equals' typo
Homogenize PHPDoc descriptions